### PR TITLE
ci: update ci & build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,9 @@ jobs:
         cabal: ["3.16.1.0"]
         ghc:
           - '9.6.7'
+          - '9.8.4'
+          - '9.10.3'
+          - '9.12.3'
 
     steps:
     - uses: actions/checkout@v7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,63 +13,45 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        cabal: ["3.4.0.0"]
-        ghc: ["8.8.4", "8.10.7"]
+        cabal: ["3.16.1.0"]
+        ghc:
+          - '9.6.7'
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v7
       if: github.event.action == 'opened' || github.event.action == 'synchronize' || github.event.ref == 'refs/heads/main'
 
-    - name: Configure environment
-      run: |
-          git config --global http.sslVerify false
-          echo "/nix/var/nix/profiles/per-user/$USER/profile/bin" >> "$GITHUB_PATH"
-          echo "/nix/var/nix/profiles/default/bin" >> "$GITHUB_PATH"
-          echo "NIX_SSL_CERT_FILE=$cert_file" >> "$GITHUB_ENV"
-          cert_file=/nix/var/nix/profiles/default/etc/ssl/certs/ca-bundle.crt
-          env
-
-    - name: Configure Darwin Nixpkgs
-      if: matrix.os == 'macos-latest' 
-      run: |
-        echo 'NIX_PATH="nixpkgs=channel:nixpkgs-21.11-darwin"' >> "$GITHUB_ENV"
-
-    - name: Configure Linux Nixpkgs
-      if: matrix.os == 'ubuntu-latest'
-      run: |
-        echo 'NIX_PATH="nixpkgs=channel:nixos-21.11"' >> "$GITHUB_ENV"
+    - uses: cachix/install-nix-action@v31
+      with:
+        nix_path: nixpkgs=channel:nixos-unstable
 
     - name: Set GHC version for Nix
       run: |
-        if [[ ${{matrix.ghc}} == '8.8.4' ]]
-        then echo "GHC='884'" >> "$GITHUB_ENV"
-        elif [[ ${{matrix.ghc}} == '8.10.7' ]]
-        then echo "GHC='8107'" >> "$GITHUB_ENV"
-        fi
-
-    - name: Install Nix
-      run: ./.github/workflows/install-nix.sh
+        printf "GHC='%s'\n" "$(sed -E 's/^([0-9]+)\.([0-9]+)\..*/\1\2/' <<<"${{matrix.ghc}}")" >>"$GITHUB_ENV"
 
     - name: Configure
-      run: nix-shell --pure -I ${{ env.NIX_PATH }} --argstr ghcVersion ${{env.GHC}} --run 'cabal update && cabal configure --enable-tests --disable-benchmarks --test-show-details=direct --disable-optimization --with-compiler="ghc-${{ matrix.ghc }}"' .github/workflows/shell.nix
+      run: |
+        mkdir -p "$HOME"/.config/nixpkgs
+        cp .github/workflows/config.nix "$HOME"/.config/nixpkgs
+        nix-shell --pure --argstr ghcVersion ${{env.GHC}} --run 'cabal update && cabal configure --enable-tests --disable-benchmarks --test-show-details=direct --disable-optimization --with-compiler="ghc-${{ matrix.ghc }}"' .github/workflows/shell.nix
 
     - name: Freeze
-      run: nix-shell --pure -I ${{ env.NIX_PATH }} --argstr ghcVersion ${{env.GHC}} --run 'cabal freeze' .github/workflows/shell.nix
- 
-    - uses: actions/cache@v2
+      run: nix-shell --pure --argstr ghcVersion ${{env.GHC}} --run 'cabal freeze' .github/workflows/shell.nix
+
+    - uses: actions/cache@v6
       name: Cache ~/.cabal/store
       with:
         path: ~/.cabal/store
         key: ${{ runner.os }}-${{ matrix.ghc }}-${{ hashFiles('cabal.project.freeze') }}
 
-    - name: Installing dependencies 
-      run: nix-shell --pure -I ${{ env.NIX_PATH }} --argstr ghcVersion ${{env.GHC}} --run 'make deps' .github/workflows/shell.nix
+    - name: Installing dependencies
+      run: nix-shell --pure --argstr ghcVersion ${{env.GHC}} --run 'make deps' .github/workflows/shell.nix
 
     - name: Running hlint
-      run: nix-shell --pure -I ${{ env.NIX_PATH }} --argstr ghcVersion ${{env.GHC}} --run './.github/workflows/hlint-runner.sh' .github/workflows/shell.nix
+      run: nix-shell --pure --argstr ghcVersion ${{env.GHC}} --run './.github/workflows/hlint-runner.sh' .github/workflows/shell.nix
 
     - name: Build
-      run: nix-shell --pure -I ${{ env.NIX_PATH }} --argstr ghcVersion ${{env.GHC}} --run 'make build' .github/workflows/shell.nix
+      run: nix-shell --pure --argstr ghcVersion ${{env.GHC}} --run 'make build' .github/workflows/shell.nix
 
     - name: Test
-      run: nix-shell --pure -I ${{ env.NIX_PATH }} --argstr ghcVersion ${{env.GHC}} --run 'make test' .github/workflows/shell.nix
+      run: nix-shell --pure --argstr ghcVersion ${{env.GHC}} --run 'make test' .github/workflows/shell.nix

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,10 +30,7 @@ jobs:
         printf "GHC='%s'\n" "$(sed -E 's/^([0-9]+)\.([0-9]+)\..*/\1\2/' <<<"${{matrix.ghc}}")" >>"$GITHUB_ENV"
 
     - name: Configure
-      run: |
-        mkdir -p "$HOME"/.config/nixpkgs
-        cp .github/workflows/config.nix "$HOME"/.config/nixpkgs
-        nix-shell --pure --argstr ghcVersion ${{env.GHC}} --run 'cabal update && cabal configure --enable-tests --disable-benchmarks --test-show-details=direct --disable-optimization --with-compiler="ghc-${{ matrix.ghc }}"' .github/workflows/shell.nix
+      run: nix-shell --pure --argstr ghcVersion ${{env.GHC}} --run 'cabal update && cabal configure --enable-tests --disable-benchmarks --test-show-details=direct --disable-optimization --with-compiler="ghc-${{ matrix.ghc }}"' .github/workflows/shell.nix
 
     - name: Freeze
       run: nix-shell --pure --argstr ghcVersion ${{env.GHC}} --run 'cabal freeze' .github/workflows/shell.nix

--- a/.github/workflows/config.nix
+++ b/.github/workflows/config.nix
@@ -1,5 +1,0 @@
-{
-  problems.handlers = {
-    apply-refact.broken = "warn";
-  };
-}

--- a/.github/workflows/config.nix
+++ b/.github/workflows/config.nix
@@ -1,0 +1,5 @@
+{
+  problems.handlers = {
+    apply-refact.broken = "warn";
+  };
+}

--- a/.github/workflows/hlint-runner.sh
+++ b/.github/workflows/hlint-runner.sh
@@ -6,7 +6,7 @@ source .github/workflows/cpus.sh
 
 git add .
 
-find src test -name "*.hs" | parallel -j "$CPUS" -- hlint --refactor-options="-i" --refactor {}
+find src test -name "*.hs" | parallel -j "$CPUS" -- hlint {}
 
 git status
 
@@ -15,8 +15,7 @@ set +e
 git diff --exit-code
 diff_code=$?
 
-if [ $diff_code -ne 0 ]
-then
-  echo "Test Hlint failed"
-  exit 1
+if [ $diff_code -ne 0 ]; then
+	echo "Test Hlint failed"
+	exit 1
 fi

--- a/.github/workflows/shell.nix
+++ b/.github/workflows/shell.nix
@@ -11,7 +11,7 @@ in with pkgs;
       stylish-haskell
 
       # DB Deps
-      postgresql_13
+      postgresql_18
       gmp
       zlib
       glibcLocales

--- a/.github/workflows/shell.nix
+++ b/.github/workflows/shell.nix
@@ -7,7 +7,6 @@ in with pkgs;
       haskell.compiler."ghc${ghcVersion}"
       cabal-install
       hlint
-      haskellPackages.apply-refact
       stylish-haskell
 
       # DB Deps

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ test: ## Run the test suite
 	@cabal test all
 
 lint: ## Run the code linter (HLint)
-	@find test src -name "*.hs" | xargs -P 12 -I {} hlint --refactor-options="-i" --refactor {}
+	@find test src -name "*.hs" | xargs -P 12 -I {} hlint {}
 	@cabal-fmt -i effectful-cache.cabal
 
 help:

--- a/cabal.project
+++ b/cabal.project
@@ -1,3 +1,3 @@
 packages: ./
 
-with-compiler: ghc-8.10
+with-compiler: ghc-9.10

--- a/effectful-cache.cabal
+++ b/effectful-cache.cabal
@@ -9,6 +9,13 @@ author:             Hécate Moonlight
 maintainer:         Hécate Moonlight
 license:            MIT
 build-type:         Simple
+tested-with: GHC ==
+  { 9.6.7
+  , 9.8.4
+  , 9.10.3
+  , 9.12.3
+  }
+
 extra-source-files:
   CHANGELOG.md
   LICENSE.md

--- a/effectful-cache.cabal
+++ b/effectful-cache.cabal
@@ -48,7 +48,7 @@ library
   hs-source-dirs:  src
   exposed-modules: Effectful.Cache
   build-depends:
-    , base            <=4.17
+    , base            <=4.22
     , cache
     , effectful-core ^>=1.0
     , hashable


### PR DESCRIPTION
several deprecated things:

- github actions versions
- used officiel nixos actions type
- add more recent versions of ghc, remove older versions that no one likely uses anymore
- removed `apply-refactor` which is broken on more recent ghc versions & marked as broken in `nixos-unstable`

this is a prelude before more contributions, i would also like to upload this package to hackage if you don't mind (i have an uploader account)