### PR TITLE
feat: add xdg file cache interpreter

### DIFF
--- a/cache-effectful.cabal
+++ b/cache-effectful.cabal
@@ -59,11 +59,19 @@ library
   import: common-extensions
   import: common-ghc-options
   hs-source-dirs: src
-  exposed-modules: Effectful.Cache
+  exposed-modules:
+    Effectful.Cache,
+    Effectful.Cache.Xdg,
   build-depends:
     base <4.23,
+    bytestring,
     cache >=0.1.3 && <0.2,
+    cereal,
+    directory,
+    effectful,
     effectful-core >=2.6 && <2.7,
+    extra,
+    filepath,
     hashable >=1.5.1 && <1.6,
 
 test-suite cache-effectful-test
@@ -72,13 +80,21 @@ test-suite cache-effectful-test
   import: common-rts-options
   type: exitcode-stdio-1.0
   main-is: Main.hs
-  other-modules: Utils
+  other-modules:
+    Utils,
+    Xdg,
   hs-source-dirs: test
   build-depends:
     base,
+    bytestring,
     cache,
     cache-effectful,
+    cereal,
+    directory,
+    effectful,
     effectful-core,
+    filepath,
     hashable,
     tasty >=1.5.4 && <1.6,
     tasty-hunit >=0.10.2 && <0.11,
+    temporary,

--- a/src/Effectful/Cache.hs
+++ b/src/Effectful/Cache.hs
@@ -29,6 +29,7 @@ module Effectful.Cache
 
 import Control.Monad.IO.Class
 import qualified Data.Cache as C
+import Data.Foldable (foldr')
 import Data.Hashable
 import Data.Kind
 import Effectful
@@ -47,7 +48,7 @@ import Prelude hiding (lookup)
 data Cache k v :: Effect where
   Insert :: (Eq k, Hashable k) => k -> v -> Cache k v m ()
   Lookup :: (Eq k, Hashable k) => k -> Cache k v m (Maybe v)
-  Keys :: Cache k v m [k]
+  Keys :: (Applicative t, Monoid (t k), Foldable t) => Cache k v m (t k)
   Delete :: (Eq k, Hashable k) => k -> Cache k v m ()
   FilterWithKey :: (Eq k, Hashable k) => (k -> v -> Bool) -> Cache k v m ()
 
@@ -67,7 +68,7 @@ runCacheIO
 runCacheIO cache = interpret $ \_ -> \case
   Insert key value -> liftIO $ C.insert cache key value
   Lookup key -> liftIO $ C.lookup cache key
-  Keys -> liftIO $ C.keys cache
+  Keys -> foldr' mappend mempty . fmap pure <$> liftIO (C.keys cache)
   Delete key -> liftIO $ C.delete cache key
   FilterWithKey fun -> liftIO $ C.filterWithKey fun cache
 

--- a/src/Effectful/Cache/Xdg.hs
+++ b/src/Effectful/Cache/Xdg.hs
@@ -1,0 +1,180 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE Strict #-}
+{-# LANGUAGE TypeFamilies #-}
+
+-- |
+--   Module      : Effectful.Cache.Xdg
+--   Copyright   : © drlkf, 2026
+--   License     : MIT
+--   Maintainer  : hecate@glitchbra.in
+--   Stability   : stable
+--
+--   A file-backed 'Cache' interpreter storing values under the XDG cache
+--   directory.
+module Effectful.Cache.Xdg
+  ( -- * Types
+    XdgCacheError (..)
+
+    -- * Handlers
+  , runCacheXdg
+
+    -- * Cache operations
+  , szInsert
+  , dzLookup
+
+    -- * Helpers
+  , validateKey
+  ) where
+
+import Control.Monad (forM_, unless)
+import Control.Monad.Extra (ifM, whenM)
+import Data.ByteString (ByteString)
+import Data.Foldable (foldlM)
+import Data.Functor ((<&>))
+import Data.List (isPrefixOf)
+import Data.Serialize (Serialize, decode, encode)
+import Effectful (Eff, Effect, (:>))
+import Effectful.Cache (Cache (..), insert, lookup)
+import Effectful.Dispatch.Dynamic (interpret)
+import Effectful.Error.Dynamic (Error, throwError)
+import Effectful.FileSystem (FileSystem, createDirectoryIfMissing, doesDirectoryExist, doesFileExist, getXdgDirectory, listDirectory, removeFile)
+import Effectful.FileSystem.IO.ByteString (readFile)
+import Effectful.FileSystem.IO.File (writeBinaryFileDurableAtomic)
+import System.Directory (XdgDirectory (..))
+import System.FilePath (makeRelative, pathSeparator, splitDirectories, takeDirectory, (</>))
+import Prelude hiding (lookup, readFile, writeFile)
+
+-- | XDG cache-specific errors.
+data XdgCacheError
+  = -- | An invalid key was provided, most likely containing a @.@ or @..@ which
+    -- could cause cache directory escape.
+    InvalidKey FilePath String
+  | -- | An error occurred while deserializing a value.
+    XdgDecodeError String
+  deriving (Eq)
+
+instance Show XdgCacheError where
+  show (InvalidKey k reason) = mconcat ["invalid key '", k, "': ", reason]
+  show (XdgDecodeError reason) = "xdg cache deserialize error: " <> reason
+
+-- | Run a 'Cache' effect backed by files under @$XDG_CACHE_HOME/<namespace>@.
+--
+-- Each key is stored as a file at @$XDG_CACHE_HOME/<namespace>/<key>@, with
+-- sub-directories created on write. Keys that would escape the namespace
+-- directory (e.g. @..@ or absolute paths) are rejected.
+--
+-- Your stack must handle an 'Error XdgCacheError' effect on top of this
+-- interpreter.
+--
+-- @since UNRELEASED
+runCacheXdg
+  :: forall (es :: [Effect]) a
+   . FileSystem :> es
+  => Error XdgCacheError :> es
+  => FilePath
+  -> Eff (Cache FilePath ByteString : es) a
+  -> Eff es a
+runCacheXdg namespace = interpret $ \_ -> \case
+  Insert key value -> do
+    path <- resolveKey namespace key
+    createDirectoryIfMissing True (takeDirectory path)
+    writeBinaryFileDurableAtomic path value
+  Lookup key -> do
+    path <- resolveKey namespace key
+
+    ifM
+      (doesFileExist path)
+      (Just <$> readFile path)
+      (pure Nothing)
+  Keys -> do
+    root <- getXdgDirectory XdgCache namespace
+
+    ifM
+      (doesDirectoryExist root)
+      (fmap (makeRelative root) <$> listFilesRecursive root)
+      (pure mempty)
+  Delete key -> do
+    path <- resolveKey namespace key
+    whenM (doesFileExist path) $
+      removeFile path
+  FilterWithKey fun -> do
+    root <- getXdgDirectory XdgCache namespace
+
+    whenM (doesDirectoryExist root) $ do
+      files <- listFilesRecursive root
+      forM_ (files :: [FilePath]) $ \file -> do
+        let key = makeRelative root file
+        value <- readFile file
+        unless (fun key value) $ removeFile file
+
+-- | Insert a serialized value under the given key.
+--
+-- @since UNRELEASED
+szInsert
+  :: forall (es :: [Effect]) v
+   . Cache FilePath ByteString :> es
+  => Serialize v
+  => FilePath
+  -> v
+  -> Eff es ()
+szInsert key value = insert @FilePath @ByteString key (encode value)
+
+-- | Look up a serialized value under the given key.
+--
+-- @since UNRELEASED
+dzLookup
+  :: forall (es :: [Effect]) v
+   . Cache FilePath ByteString :> es
+  => Error XdgCacheError :> es
+  => Serialize v
+  => FilePath
+  -> Eff es (Maybe v)
+dzLookup key = do
+  mval <- lookup @FilePath @ByteString key
+  case mval of
+    Nothing -> pure Nothing
+    Just v -> either (throwError . XdgDecodeError) (pure . Just) (decode v)
+
+resolveKey
+  :: forall (es :: [Effect])
+   . FileSystem :> es
+  => Error XdgCacheError :> es
+  => FilePath
+  -> FilePath
+  -> Eff es FilePath
+resolveKey namespace key =
+  maybe
+    ((getXdgDirectory XdgCache namespace) <&> (</> key))
+    throwError
+    (validateKey key)
+
+validateKey
+  :: FilePath
+  -> Maybe XdgCacheError
+validateKey key
+  | [pathSeparator] `isPrefixOf` key =
+      Just (InvalidKey key "key be an absolute path")
+  | any ("." `isPrefixOf`) (splitDirectories key) =
+      Just (InvalidKey key "key cannot contain paths starting with '.'")
+  | otherwise = Nothing
+
+listFilesRecursive
+  :: forall (es :: [Effect]) t
+   . FileSystem :> es
+  => Foldable t
+  => Applicative t
+  => Monoid (t FilePath)
+  => FilePath
+  -> Eff es (t FilePath)
+listFilesRecursive dir = do
+  entries <- listDirectory dir
+  foldlM (\t e -> (t <>) <$> (getEntry e)) mempty entries
+  where
+    getEntry entry =
+      let path = dir </> entry
+      in ifM
+           (doesDirectoryExist path)
+           (listFilesRecursive path)
+           (pure (pure path))

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -4,12 +4,12 @@ module Main where
 
 import qualified Data.Cache as C
 import Effectful
+import Effectful.Cache
 import Test.Tasty
 import Test.Tasty.HUnit
-import Prelude hiding (lookup)
-
-import Effectful.Cache
 import qualified Utils as U
+import qualified Xdg
+import Prelude hiding (lookup)
 
 main :: IO ()
 main =
@@ -20,6 +20,7 @@ main =
       , testCase "Listing keys" $ testListKeys =<< initIntCache
       , testCase "Deleting keys" $ testDeleteKeys =<< initIntCache
       , testCase "Filter with key" $ testFilterWithKey =<< initIntCache
+      , Xdg.tests
       ]
 
 initStringCache :: IO (C.Cache String String)

--- a/test/Xdg.hs
+++ b/test/Xdg.hs
@@ -1,0 +1,182 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE PolyKinds #-}
+
+module Xdg (tests) where
+
+import Control.Exception (finally)
+import Data.ByteString (ByteString)
+import Data.List (sort)
+import Data.Maybe (isJust)
+import Effectful (Eff, Effect, IOE, runEff, (:>))
+import Effectful.Cache (Cache, delete, filterWithKey, insert, keys, lookup)
+import Effectful.Cache.Xdg (XdgCacheError)
+import qualified Effectful.Cache.Xdg as X
+import Effectful.Error.Dynamic (Error, runErrorNoCallStack)
+import Effectful.FileSystem (FileSystem, runFileSystem)
+import System.Environment (lookupEnv, setEnv, unsetEnv)
+import System.FilePath ((</>))
+import System.IO.Temp (createTempDirectory, getCanonicalTemporaryDirectory)
+import Test.Tasty (DependencyType (..), TestTree, dependentTestGroup, testGroup)
+import Test.Tasty.HUnit (Assertion, assertBool, testCase)
+import qualified Utils as U
+import Prelude hiding (lookup)
+
+tests :: TestTree
+tests =
+  testGroup
+    "Xdg"
+    -- sequential to avoid env collisions
+    [ dependentTestGroup
+        "files"
+        AllSucceed
+        [ testCase "Insert & Lookup" testInsertAndLookup
+        , testCase "Listing keys" testListKeys
+        , testCase "Deleting keys" testDeleteKeys
+        , testCase "Filter with key" testFilterWithKey
+        , testCase "szInsert/dzLookup roundtrip" testSerializedRoundtrip
+        ]
+    , testGroup
+        "validation"
+        [ testCase "Path with dot rejected" testPathEscapeDot
+        , testCase "Absolute path rejected" testPathEscapeAbs
+        ]
+    ]
+
+runXdgWithError
+  :: forall (es :: [Effect]) a
+   . IOE :> es
+  => Eff (Cache FilePath ByteString : FileSystem : Error XdgCacheError : es) a
+  -> Eff es (Either XdgCacheError a)
+runXdgWithError =
+  runErrorNoCallStack
+    . runFileSystem
+    . X.runCacheXdg "test-cache"
+
+withXdgCache :: (FilePath -> IO a) -> IO a
+withXdgCache action = do
+  -- leave the directory present after tests for inspection in case of failure
+  dir <-
+    flip createTempDirectory "cache-effectful-test"
+      =<< getCanonicalTemporaryDirectory
+
+  old <- lookupEnv "XDG_CACHE_HOME"
+  setEnv "XDG_CACHE_HOME" dir
+  action dir
+    `finally` maybe (unsetEnv "XDG_CACHE_HOME") (setEnv "XDG_CACHE_HOME") old
+
+testInsertAndLookup :: Assertion
+testInsertAndLookup = withXdgCache $ \_ -> runEff $ do
+  result <- runXdgWithError insertAndLookup
+  U.assertEqual
+    "Looking up a nested key yields the value"
+    (Right (Just v))
+    result
+  where
+    k :: FilePath
+    k = "full" </> "path" </> "to" </> "key"
+    v :: ByteString
+    v = "hello"
+    insertAndLookup
+      :: Cache FilePath ByteString :> es
+      => Eff es (Maybe ByteString)
+    insertAndLookup = do
+      insert k v
+      lookup k
+
+testListKeys :: Assertion
+testListKeys = withXdgCache $ \_ -> runEff $ do
+  result <- runXdgWithError listKeys
+  U.assertEqual
+    "Keys are relative paths under the namespace"
+    ( Right
+        [ "a" </> "b" </> "c"
+        , "a" </> "d"
+        , "top"
+        ]
+    )
+    (fmap sort result)
+  where
+    listKeys = do
+      mapM_
+        (flip (insert @FilePath @ByteString) "v")
+        [ "a" </> "b" </> "c"
+        , "a" </> "d"
+        , "top"
+        ]
+      keys @FilePath @ByteString
+
+testDeleteKeys :: Assertion
+testDeleteKeys = withXdgCache $ \_ -> runEff $ do
+  result <- runXdgWithError deleteKeys
+  U.assertEqual
+    "Deleted key is gone, others remain"
+    (Right ["a" </> "b" </> "c", "top"])
+    (fmap sort result)
+  where
+    deleteKeys
+      :: Cache FilePath ByteString :> es
+      => Eff es [FilePath]
+    deleteKeys = do
+      mapM_
+        (flip (insert @FilePath @ByteString) "v")
+        [ "a" </> "b" </> "c"
+        , "a" </> "d"
+        , "top"
+        ]
+      delete @FilePath @ByteString ("a" </> "d")
+      keys @FilePath @ByteString
+
+testFilterWithKey :: Assertion
+testFilterWithKey = withXdgCache $ \_ -> runEff $ do
+  result <- runXdgWithError filterKeys
+  U.assertEqual
+    "Keys are properly filtered"
+    ( Right
+        [ "a" </> "b" </> "c"
+        , "top"
+        ]
+    )
+    (fmap sort result)
+  where
+    filterKeys
+      :: Cache FilePath ByteString :> es
+      => Eff es [FilePath]
+    filterKeys = do
+      mapM_
+        (flip (insert @FilePath @ByteString) "v")
+        [ "a" </> "b" </> "c"
+        , "a" </> "d"
+        , "top"
+        ]
+      filterWithKey @FilePath @ByteString (\key _ -> key /= "a" </> "d")
+      keys @FilePath @ByteString
+
+testPathEscapeDot :: Assertion
+testPathEscapeDot =
+  assertBool
+    "Relative escape is rejected"
+    (isJust @XdgCacheError (X.validateKey (".." </> "outside")))
+
+testPathEscapeAbs :: Assertion
+testPathEscapeAbs = do
+  dir <- getCanonicalTemporaryDirectory
+
+  assertBool
+    "Absolute key is rejected"
+    (isJust @XdgCacheError (X.validateKey (dir </> "abs")))
+
+testSerializedRoundtrip :: Assertion
+testSerializedRoundtrip = withXdgCache $ \_ -> runEff $ do
+  result <- runXdgWithError roundtrip
+  U.assertEqual
+    "Serialized value roundtrips"
+    (Right (Just (42 :: Int)))
+    result
+  where
+    roundtrip
+      :: Cache FilePath ByteString :> es
+      => Error XdgCacheError :> es
+      => Eff es (Maybe Int)
+    roundtrip = do
+      X.szInsert "answer" (42 :: Int)
+      X.dzLookup "answer"


### PR DESCRIPTION
Add an interpreter to store cache as files in `XDG_CACHE_HOME`. I use this extensively for local CLI tools with idempotency and/or binary dependencies.

- I used `cereal` for {,de}serialization, as it seems to be the most pragmatic choice, performance might not be the best but it seems good enough for most use-cases and the developer API is quite nice
- I made use of `effectful` base effects (namely `FileSystem`) for consistency which required importing the full `effectful` package, hope you don't mind, they are literally lifted re-exports so using raw `IO` would change almost nothing besides a few `liftIO` here and there so if you want to avoid the extra pull it's no big deal
- I chose to scope this interpreter's errors self-contained so it doesn't clutter the main effect's API, let me know if you disagree
- Generalized `Keys` to constraint-based containers because I don't like lists; `Data.Cache` uses `Data.HashMap.Strict` which states the list of keys is [produced lazily](https://hackage-content.haskell.org/package/unordered-containers-0.2.21/docs/Data-HashMap-Strict.html#v:keys) so performance impact on the original interpreter should be minimal
- I left the `@since` comments at `UNRELEASED` for you to pick your release cycle
